### PR TITLE
52 complete styling for summarydetail component amt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
       "dev": true,
       "funding": [
         {
@@ -1782,9 +1782,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.579",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.579.tgz",
-      "integrity": "sha512-bJKvA+awBIzYR0xRced7PrQuRIwGQPpo6ZLP62GAShahU9fWpsNN2IP6BSP1BLDDSbxvBVRGAMWlvVVq3npmLA==",
+      "version": "1.4.582",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.582.tgz",
+      "integrity": "sha512-89o0MGoocwYbzqUUjc+VNpeOFSOK9nIdC5wY4N+PVUarUK0MtjyTjks75AZS2bW4Kl8MdewdFsWaH0jLy+JNoA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2552,9 +2552,9 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -2562,7 +2562,7 @@
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -4070,9 +4070,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
-      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "peerDependencies": {
         "react": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "axios": "^1.5.1",
         "dotenv": "^16.3.1",
-        "nanoid": "^5.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0"
@@ -81,30 +80,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-      "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.0",
+        "@babel/parser": "^7.23.3",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -120,12 +119,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -197,9 +196,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -304,9 +303,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -316,9 +315,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.22.5.tgz",
-      "integrity": "sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.23.3.tgz",
+      "integrity": "sha512-qXRvbeKDSfwnlJnanVRp0SfuWE5DQhwQr5xtLBzp56Wabyo+4CMosF6Kfp+eOD/4FYpql64XVJ2W0pVLlJZxOQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -331,9 +330,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.22.5.tgz",
-      "integrity": "sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.23.3.tgz",
+      "integrity": "sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -372,19 +371,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -393,9 +392,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -774,18 +773,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
+      "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -821,9 +820,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
+      "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -968,9 +967,9 @@
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
-      "integrity": "sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.4.tgz",
+      "integrity": "sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -981,18 +980,18 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.6.tgz",
-      "integrity": "sha512-66BXMKb/sUWbMdBNdMvajU7i/44RkrA3z/Yt1c7R5xejt8qh84iU54yUWCtm0QwGJlDcf/gg4zd/x4mpLAlb/w==",
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
+      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.3.tgz",
-      "integrity": "sha512-ciwyCLeuRfxboZ4isgdNZi/tkt06m8Tw6uGbBSBgWrnnZGNXiEyM27xc/PjXGQLqlZ6ylbgHMnm7ccF9tCkOeQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1000,18 +999,18 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.3.tgz",
-      "integrity": "sha512-Lsh766rGEFbaxMIDH7Qa+Yha8cMVI3qAK6CHt3OR0YfxOIn5Z54iHiyDRycHrBqeIiqGa20Kpsv1cavfBKkRSw==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
+      "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.44.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.6.tgz",
-      "integrity": "sha512-P6bY56TVmX8y9J87jHNgQh43h6VVU+6H7oN7hgvivV81K2XY8qJZ5vqPy/HdUoVIelii2kChYVzQanlswPWVFw==",
+      "version": "8.44.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
+      "integrity": "sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1020,15 +1019,15 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.3.tgz",
-      "integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "peer": true
     },
@@ -1039,15 +1038,15 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-      "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==",
+      "version": "15.7.10",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
+      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==",
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.31.tgz",
-      "integrity": "sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==",
+      "version": "18.2.37",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
+      "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1056,30 +1055,36 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
-      "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
+      "version": "18.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.15.tgz",
+      "integrity": "sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
-      "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
+      "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA==",
+      "dev": true
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.1.0.tgz",
-      "integrity": "sha512-rM0SqazU9iqPUraQ2JlIvReeaxOoRj6n+PzB1C0cBzIbd8qP336nC39/R9yPi3wVcah7E7j/kdU1uCUqMEU4OQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.1.1.tgz",
+      "integrity": "sha512-Jie2HERK+uh27e+ORXXwEP5h0Y2lS9T2PRGbfebiHGlwzDO0dEnd2aNtOR/qjBlPb1YgxwAONeblL1xqLikLag==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.22.20",
+        "@babel/core": "^7.23.2",
         "@babel/plugin-transform-react-jsx-self": "^7.22.5",
         "@babel/plugin-transform-react-jsx-source": "^7.22.5",
-        "@types/babel__core": "^7.20.2",
+        "@types/babel__core": "^7.20.3",
         "react-refresh": "^0.14.0"
       },
       "engines": {
@@ -1090,9 +1095,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1309,9 +1314,9 @@
       }
     },
     "node_modules/ast-types-flow": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
     "node_modules/asynciterator.prototype": {
@@ -1378,18 +1383,18 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
-      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -1507,9 +1512,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001551",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
-      "integrity": "sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==",
+      "version": "1.0.30001561",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
+      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
       "dev": true,
       "funding": [
         {
@@ -1777,9 +1782,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.562",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.562.tgz",
-      "integrity": "sha512-kMGVZLP65O2/oH7zzaoIA5hcr4/xPYO6Sa83FrIpWcd7YPPtSlxqwxTd8lJIwKxaiXM6FGsYK4ukyJ40XkW7jg==",
+      "version": "1.4.579",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.579.tgz",
+      "integrity": "sha512-bJKvA+awBIzYR0xRced7PrQuRIwGQPpo6ZLP62GAShahU9fWpsNN2IP6BSP1BLDDSbxvBVRGAMWlvVVq3npmLA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1789,26 +1794,26 @@
       "dev": true
     },
     "node_modules/es-abstract": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
-      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+      "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "arraybuffer.prototype.slice": "^1.0.2",
         "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.5",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.1",
+        "get-intrinsic": "^1.2.2",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0",
         "internal-slot": "^1.0.5",
         "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
@@ -1818,7 +1823,7 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.12",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.3",
+        "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.5.1",
@@ -1832,7 +1837,7 @@
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1864,26 +1869,26 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+      "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
-        "has": "^1.0.3",
-        "has-tostringtag": "^1.0.0"
+        "get-intrinsic": "^1.2.2",
+        "has-tostringtag": "^1.0.0",
+        "hasown": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "node_modules/es-to-primitive": {
@@ -1959,18 +1964,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
+      "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.51.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.3",
+        "@eslint/js": "8.53.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2099,26 +2105,26 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
+      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.2"
       },
@@ -2151,27 +2157,27 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
-      "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
+      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "aria-query": "^5.1.3",
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.6.2",
-        "axobject-query": "^3.1.1",
+        "@babel/runtime": "^7.23.2",
+        "aria-query": "^5.3.0",
+        "array-includes": "^3.1.7",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "=4.7.0",
+        "axobject-query": "^3.2.1",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^3.3.3",
-        "language-tags": "=1.0.5",
+        "es-iterator-helpers": "^1.0.15",
+        "hasown": "^2.0.0",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "semver": "^6.3.0"
+        "object.entries": "^1.1.7",
+        "object.fromentries": "^2.0.7"
       },
       "engines": {
         "node": ">=4.0"
@@ -2223,9 +2229,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.3.tgz",
-      "integrity": "sha512-Hh0wv8bUNY877+sI0BlCUlsS0TYYQqvzEwJsJJPM2WF4RnTStSnSR3zdJYa2nPOJgg3UghXi54lVyMSmpCalzA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.4.tgz",
+      "integrity": "sha512-eD83+65e8YPVg6603Om2iCIwcQJf/y7++MWm4tACtEswFLYMwxwVWAfwN+e19f5Ad/FOyyNg9Dfi5lXhH3Y3rA==",
       "dev": true,
       "peerDependencies": {
         "eslint": ">=7"
@@ -2457,9 +2463,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2685,15 +2691,15 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2789,15 +2795,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -2817,12 +2814,12 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "get-intrinsic": "^1.2.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2865,6 +2862,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -2918,13 +2927,13 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+      "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
+        "get-intrinsic": "^1.2.2",
+        "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "engines": {
@@ -3013,12 +3022,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3283,9 +3292,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.20.0.tgz",
-      "integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
@@ -3381,12 +3390,15 @@
       "dev": true
     },
     "node_modules/language-tags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "dependencies": {
-        "language-subtag-registry": "~0.3.2"
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/levn": {
@@ -3538,9 +3550,10 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.2.tgz",
-      "integrity": "sha512-2ustYUX1R2rL/Br5B/FMhi8d5/QzvkJ912rBYxskcpu0myTHzSZfTr1LAS2Sm7jxRUObRrSBFoyzwAhL49aVSg==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3548,10 +3561,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -3979,24 +3992,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4023,9 +4018,9 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4538,9 +4533,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
-      "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
+      "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -4548,10 +4543,10 @@
         "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
+        "jiti": "^1.19.1",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -4857,15 +4852,14 @@
       }
     },
     "node_modules/vite-plugin-eslint2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-eslint2/-/vite-plugin-eslint2-4.2.0.tgz",
-      "integrity": "sha512-UPDQBKL981XAUm+fXtMTO1MqtuAy2oa8d9H4E7FAjad/X9fLNVhMsINfiq2c816mr/8MyUzDHq0BagPUyr71Zg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-eslint2/-/vite-plugin-eslint2-4.3.0.tgz",
+      "integrity": "sha512-ijJo/ONe1cLG9v2rS6pwnkFTL4QVTj/8h7hZb+sn7zf7ZYCmZW4faTV95nFslYVOTylmEwFnfCIfHjMqgKrqxw==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.5",
         "chokidar": "^3.5.3",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.1"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">=14.18"
@@ -4873,8 +4867,8 @@
       "peerDependencies": {
         "@types/eslint": "^7.0.0 || ^8.0.0",
         "eslint": "^7.0.0 || ^8.0.0",
-        "rollup": "^2.0.0 || ^3.0.0",
-        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+        "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -4986,9 +4980,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "dev": true,
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "axios": "^1.5.1",
     "dotenv": "^16.3.1",
-    "nanoid": "^5.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,6 @@ function App() {
 
   function handleSummaryDetailClose() {
     setIsDetailShown(false);
-    setRecipeDetail(null);
   }
 
   return (
@@ -82,17 +81,15 @@ function App() {
 
       {isDetailShown
           && (
-            <>
-              <BackgroundBlur
-                handleSummaryDetailClose={handleSummaryDetailClose}
-              />
-              <SummaryDetail
-                recipeDetail={recipeDetail}
-                isDetailShown={isDetailShown}
-                handleSummaryDetailClose={handleSummaryDetailClose}
-              />
-            </>
+          <BackgroundBlur
+            handleSummaryDetailClose={handleSummaryDetailClose}
+          />
           )}
+      <SummaryDetail
+        recipeDetail={recipeDetail}
+        isDetailShown={isDetailShown}
+        handleSummaryDetailClose={handleSummaryDetailClose}
+      />
       <Footer />
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,15 +59,15 @@ function App() {
 
   function handleRecipeCardClick(recipe) {
     setRecipeDetail(recipe);
-    toggleIsDetailShown();
+    setIsDetailShown(true);
   }
 
-  function toggleIsDetailShown() {
-    setIsDetailShown((prevIsDetailShown) => !prevIsDetailShown);
-  }
+  // function toggleIsDetailShown() {
+  //   setIsDetailShown((prevIsDetailShown) => !prevIsDetailShown);
+  // }
 
   function handleSummaryDetailClose() {
-    toggleIsDetailShown();
+    setIsDetailShown(false);
     setRecipeDetail(null);
   }
 

--- a/src/components/summaryDetail/Ingredients.jsx
+++ b/src/components/summaryDetail/Ingredients.jsx
@@ -1,9 +1,17 @@
 export default function Ingredients({ recipeId, sections }) {
-  const ingredientEls = sections.map((section) => section.components.map((component) => (<p key={recipeId + component.id} className="pb-2 text-xs">{component.raw_text}</p>)));
+  const ingredientEls = sections.map((section) => section.components.map((component) => (
+    <li key={recipeId + component.id} className="pb-2 text-xs">
+      &#8226;
+      {' '}
+      {component.raw_text}
+    </li>
+  )));
 
   return (
     <div className="rounded-2xl py-5 px-4 bg-gray-100">
-      {ingredientEls}
+      <ul>
+        {ingredientEls}
+      </ul>
     </div>
   );
 }

--- a/src/components/summaryDetail/Nutrition.jsx
+++ b/src/components/summaryDetail/Nutrition.jsx
@@ -1,3 +1,5 @@
+import './SummaryDetail.css';
+
 export default function Nutrition({ recipeId, nutrition }) {
   let nutritionEls = null;
 
@@ -12,16 +14,20 @@ export default function Nutrition({ recipeId, nutrition }) {
     .filter(([key, value]) => key !== 'updated_at')
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
     .map(([key, value]) => (
-      <p key={recipeId + capitalize(key)} className="border-t text-xs">
-        {capitalize(key)}
-        {': '}
-        {value}
-      </p>
+      <div className="nutrition-row border-t flex justify-between">
+        <p key={recipeId + capitalize(key)} className="text-xs">
+          {capitalize(key)}
+        </p>
+        <p className="text-xs">
+          {value}
+        </p>
+      </div>
+
     ));
 
   return (
-    <>
+    <div className="nutrition-container">
       {nutritionEls}
-    </>
+    </div>
   );
 }

--- a/src/components/summaryDetail/SummaryDetail.css
+++ b/src/components/summaryDetail/SummaryDetail.css
@@ -1,8 +1,33 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
+
 .summary-detail-container{
+  font-family: Poppins, sans-serif;
+  line-height: 1.5;
+  letter-spacing: 0.4px;
   width: 100vw;
+  background-color: #F3FAFC;
 }
 
-@media (min-width: 1024px) {
+.ingredients-and-nutrition-container{
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.nutrition-container .nutrition-row:first-child{
+  font-weight: bold;
+}
+
+@media screen and (min-width: 480px) {
+  .ingredients-and-nutrition-container  {
+      flex-direction: row;
+      gap: 5rem;
+  }
+  .ingredient-container{
+    max-width: 284px;
+  }
+}
+
+@media screen and (min-width: 1024px) {
   .summary-detail-container{
     width: 612px;
   }

--- a/src/components/summaryDetail/SummaryDetail.css
+++ b/src/components/summaryDetail/SummaryDetail.css
@@ -1,9 +1,14 @@
-.show-summary-detail {
-    transform: translateX(0); 
-    transition: transform 1s ease; 
+.summary-detail-container{
+  width: 100vw;
+}
+
+@media (min-width: 1024px) {
+  .summary-detail-container{
+    width: 612px;
   }
 
-.hide-summary-detail {
-    transform: translateX(100%);
-    transition: transform 1s ease;
+  .recipe-detail-img{
+    max-height: 322px;
+  }
+  
 }

--- a/src/components/summaryDetail/SummaryDetail.css
+++ b/src/components/summaryDetail/SummaryDetail.css
@@ -27,6 +27,13 @@
   }
 }
 
+@media screen and (min-width: 768px) {
+  .summary-detail-container  {
+      border-radius: 24px 0 0 24px;
+  }
+
+}
+
 @media screen and (min-width: 1024px) {
   .summary-detail-container{
     width: 612px;

--- a/src/components/summaryDetail/SummaryDetail.jsx
+++ b/src/components/summaryDetail/SummaryDetail.jsx
@@ -47,23 +47,25 @@ export default function SummaryDetail({
             <img src={thumbnailUrl} className="w-full max-h-full object-cover object-center" />
           </div>
 
-          <button onClick={handleSummaryDetailClose} className="close-btn self-end fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">
+          <button onClick={handleSummaryDetailClose} className="close-btn self-end fixed top-4 right-1 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">
             <AiOutlineClose style={closeBtnStyles} />
           </button>
 
-          <div className="w-11/12 bg-pink">
+          <div className="w-11/12">
 
-            <h2 className="self-start py-10 border-b-2 border-grey-300 text-3xl font-semibold">{name}</h2>
+            <h2 className="self-start py-7 border-b-2 border-grey-300 text-3xl font-semibold">{name}</h2>
 
-            <div className="flex gap-20 max-w-11/12 py-10">
-              <div>
+            <div className="ingredients-and-nutrition-container flex max-w-11/12 py-7 ">
+
+              <div className="ingredient-container">
                 <h3 className="font-semibold pb-5">Ingredients</h3>
                 <Ingredients
                   recipeId={recipeId}
                   sections={sections}
                 />
               </div>
-              <div>
+
+              <div className="flex-grow">
                 <div className="flex gap-4 items-center pb-5">
                   <h3 className="font-semibold">Nutrition</h3>
                   <button onClick={toggleNutrition} type="button">

--- a/src/components/summaryDetail/SummaryDetail.jsx
+++ b/src/components/summaryDetail/SummaryDetail.jsx
@@ -21,67 +21,69 @@ export default function SummaryDetail({
   }
 
   return (
-    <div className={`${isDetailShown ? 'show-summary-detail' : 'hide-summary-detail'} fixed top-0 right-0 h-full max-w-2xl bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4`}>
+    <>
+      <button onClick={handleSummaryDetailClose} className="fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">X</button>
 
-      <button onClick={handleSummaryDetailClose} className="self-end fixed top-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center" type="button">X</button>
+      <div className={`${isDetailShown ? 'show-summary-detail' : 'hide-summary-detail'} fixed top-0 right-0 h-full max-w-2xl bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4`}>
 
-      <div className="self-center h-1/4">
-        <img src={thumbnailUrl} className="object-fit position-center max-h-full rounded-md pt-4" />
-      </div>
-
-      <div className="w-11/12 bg-pink">
-
-        <h2 className="self-start py-10 border-b-2 border-grey-300 text-3xl font-semibold">{name}</h2>
-
-        <div className="flex gap-20 max-w-11/12 py-10">
-          <div>
-            <h3 className="font-semibold pb-5">Ingredients</h3>
-            <Ingredients
-              recipeId={recipeId}
-              sections={sections}
-            />
-          </div>
-          <div>
-            <div className="flex gap-4 items-center pb-5">
-              <h3 className="font-semibold">Nutrition</h3>
-              <button onClick={toggleNutrition} type="button">
-                {isNutritionShown
-                  ? <FiChevronUp />
-                  : <FiChevronDown />}
-              </button>
-            </div>
-            {isNutritionShown
-              && (
-              <Nutrition
-                recipeId={recipeId}
-                nutrition={nutrition}
-              />
-              )}
-
-          </div>
+        <div className="self-center h-1/4">
+          <img src={thumbnailUrl} className="object-fit position-center max-h-full rounded-md pt-4" />
         </div>
 
-        <h3 className="font-semibold">Instructions</h3>
-        <Instructions
-          recipeId={recipeId}
-          instructions={instructions}
-        />
+        <div className="w-11/12 bg-pink">
 
-        {videoUrl
-          && (
-          <a href={videoUrl} target="_blank" className="flex items-center gap-3 pt-10 text-xs" rel="noreferrer">
-            <FiVideo />
-            {' '}
-            HOW TO VIDEO
-          </a>
-          )}
+          <h2 className="self-start py-10 border-b-2 border-grey-300 text-3xl font-semibold">{name}</h2>
 
-        <Categories
-          tags={tags}
-        />
+          <div className="flex gap-20 max-w-11/12 py-10">
+            <div>
+              <h3 className="font-semibold pb-5">Ingredients</h3>
+              <Ingredients
+                recipeId={recipeId}
+                sections={sections}
+              />
+            </div>
+            <div>
+              <div className="flex gap-4 items-center pb-5">
+                <h3 className="font-semibold">Nutrition</h3>
+                <button onClick={toggleNutrition} type="button">
+                  {isNutritionShown
+                    ? <FiChevronUp />
+                    : <FiChevronDown />}
+                </button>
+              </div>
+              {isNutritionShown
+                && (
+                <Nutrition
+                  recipeId={recipeId}
+                  nutrition={nutrition}
+                />
+                )}
+
+            </div>
+          </div>
+
+          <h3 className="font-semibold">Instructions</h3>
+          <Instructions
+            recipeId={recipeId}
+            instructions={instructions}
+          />
+
+          {videoUrl
+            && (
+            <a href={videoUrl} target="_blank" className="flex items-center gap-3 pt-10 text-xs" rel="noreferrer">
+              <FiVideo />
+              {' '}
+              HOW TO VIDEO
+            </a>
+            )}
+
+          <Categories
+            tags={tags}
+          />
+
+        </div>
 
       </div>
-
-    </div>
+    </>
   );
 }

--- a/src/components/summaryDetail/SummaryDetail.jsx
+++ b/src/components/summaryDetail/SummaryDetail.jsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import './SummaryDetail.css';
-import { FiChevronUp, FiChevronDown, FiVideo } from 'react-icons/fi';
+import {
+  FiChevronUp, FiChevronDown, FiVideo,
+} from 'react-icons/fi';
+import { AiOutlineClose } from 'react-icons/ai';
 
 import Ingredients from './Ingredients';
 import Nutrition from './Nutrition';
@@ -16,6 +19,10 @@ export default function SummaryDetail({
     name, id: recipeId, thumbnail_url: thumbnailUrl, original_video_url: videoUrl, nutrition, instructions, sections, tags,
   } = recipeDetail;
 
+  const closeBtnStyles = {
+    color: 'white', zIndex: 11, position: 'fixed', top: '1 rem', right: '1 rem',
+  };
+
   function toggleNutrition() {
     setIsNutritionShown((prevIsNutritionShown) => !prevIsNutritionShown);
   }
@@ -27,7 +34,9 @@ export default function SummaryDetail({
 
   return (
     <>
-      <button onClick={handleSummaryDetailClose} className="fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">X</button>
+      <button onClick={handleSummaryDetailClose} className="close-btn fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">
+        <AiOutlineClose style={closeBtnStyles} />
+      </button>
 
       <div style={containerStyle} className="summary-detail-container fixed top-0 right-0 h-full bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4">
 

--- a/src/components/summaryDetail/SummaryDetail.jsx
+++ b/src/components/summaryDetail/SummaryDetail.jsx
@@ -20,14 +20,19 @@ export default function SummaryDetail({
     setIsNutritionShown((prevIsNutritionShown) => !prevIsNutritionShown);
   }
 
+  const containerStyle = {
+    transform: isDetailShown ? 'translateX(0)' : 'translateX(100%)',
+    transition: 'transform 1s ease',
+  };
+
   return (
     <>
       <button onClick={handleSummaryDetailClose} className="fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">X</button>
 
-      <div className={`${isDetailShown ? 'show-summary-detail' : 'hide-summary-detail'} fixed top-0 right-0 h-full max-w-2xl bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4`}>
+      <div style={containerStyle} className="summary-detail-container fixed top-0 right-0 h-full bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4">
 
-        <div className="self-center h-1/4">
-          <img src={thumbnailUrl} className="object-fit position-center max-h-full rounded-md pt-4" />
+        <div className="recipe-detail-img h-1/3 w-full">
+          <img src={thumbnailUrl} className="w-full max-h-full object-cover object-center" />
         </div>
 
         <div className="w-11/12 bg-pink">

--- a/src/components/summaryDetail/SummaryDetail.jsx
+++ b/src/components/summaryDetail/SummaryDetail.jsx
@@ -15,89 +15,98 @@ export default function SummaryDetail({
 }) {
   const [isNutritionShown, setIsNutritionShown] = useState(false);
 
-  const {
-    name, id: recipeId, thumbnail_url: thumbnailUrl, original_video_url: videoUrl, nutrition, instructions, sections, tags,
-  } = recipeDetail;
+  let name; let recipeId; let thumbnailUrl; let videoUrl; let nutrition; let instructions; let sections; let
+    tags;
+
+  if (recipeDetail) {
+    ({
+      name, id: recipeId, thumbnail_url: thumbnailUrl, original_video_url: videoUrl, nutrition, instructions, sections, tags,
+    } = recipeDetail);
+  }
 
   const closeBtnStyles = {
     color: 'white', zIndex: 11, position: 'fixed', top: '1 rem', right: '1 rem',
   };
-
-  function toggleNutrition() {
-    setIsNutritionShown((prevIsNutritionShown) => !prevIsNutritionShown);
-  }
 
   const containerStyle = {
     transform: isDetailShown ? 'translateX(0)' : 'translateX(100%)',
     transition: 'transform 1s ease',
   };
 
+  function toggleNutrition() {
+    setIsNutritionShown((prevIsNutritionShown) => !prevIsNutritionShown);
+  }
+
   return (
+
     <>
-      <button onClick={handleSummaryDetailClose} className="close-btn fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">
-        <AiOutlineClose style={closeBtnStyles} />
-      </button>
+      {recipeDetail && (
+        <div style={containerStyle} className="summary-detail-container fixed top-0 right-0 h-full bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4">
 
-      <div style={containerStyle} className="summary-detail-container fixed top-0 right-0 h-full bg-white max-h-screen overflow-y-scroll inline-flex flex-col items-center pb-4">
-
-        <div className="recipe-detail-img h-1/3 w-full">
-          <img src={thumbnailUrl} className="w-full max-h-full object-cover object-center" />
-        </div>
-
-        <div className="w-11/12 bg-pink">
-
-          <h2 className="self-start py-10 border-b-2 border-grey-300 text-3xl font-semibold">{name}</h2>
-
-          <div className="flex gap-20 max-w-11/12 py-10">
-            <div>
-              <h3 className="font-semibold pb-5">Ingredients</h3>
-              <Ingredients
-                recipeId={recipeId}
-                sections={sections}
-              />
-            </div>
-            <div>
-              <div className="flex gap-4 items-center pb-5">
-                <h3 className="font-semibold">Nutrition</h3>
-                <button onClick={toggleNutrition} type="button">
-                  {isNutritionShown
-                    ? <FiChevronUp />
-                    : <FiChevronDown />}
-                </button>
-              </div>
-              {isNutritionShown
-                && (
-                <Nutrition
-                  recipeId={recipeId}
-                  nutrition={nutrition}
-                />
-                )}
-
-            </div>
+          <div className="recipe-detail-img h-1/3 w-full">
+            <img src={thumbnailUrl} className="w-full max-h-full object-cover object-center" />
           </div>
 
-          <h3 className="font-semibold">Instructions</h3>
-          <Instructions
-            recipeId={recipeId}
-            instructions={instructions}
-          />
+          <button onClick={handleSummaryDetailClose} className="close-btn self-end fixed top-4 right-4 w-4 h-4 bg-gray-700 rounded-full mr-4 p-4 text-white inline-flex items-center justify-center z-10" type="button">
+            <AiOutlineClose style={closeBtnStyles} />
+          </button>
 
-          {videoUrl
-            && (
-            <a href={videoUrl} target="_blank" className="flex items-center gap-3 pt-10 text-xs" rel="noreferrer">
-              <FiVideo />
-              {' '}
-              HOW TO VIDEO
-            </a>
-            )}
+          <div className="w-11/12 bg-pink">
 
-          <Categories
-            tags={tags}
-          />
+            <h2 className="self-start py-10 border-b-2 border-grey-300 text-3xl font-semibold">{name}</h2>
+
+            <div className="flex gap-20 max-w-11/12 py-10">
+              <div>
+                <h3 className="font-semibold pb-5">Ingredients</h3>
+                <Ingredients
+                  recipeId={recipeId}
+                  sections={sections}
+                />
+              </div>
+              <div>
+                <div className="flex gap-4 items-center pb-5">
+                  <h3 className="font-semibold">Nutrition</h3>
+                  <button onClick={toggleNutrition} type="button">
+                    {isNutritionShown
+                      ? <FiChevronUp />
+                      : <FiChevronDown />}
+                  </button>
+                </div>
+                {isNutritionShown
+                    && (
+                      <Nutrition
+                        recipeId={recipeId}
+                        nutrition={nutrition}
+                      />
+                    )}
+
+              </div>
+            </div>
+
+            <h3 className="font-semibold">Instructions</h3>
+            <Instructions
+              recipeId={recipeId}
+              instructions={instructions}
+            />
+
+            {videoUrl
+                && (
+                  <a href={videoUrl} target="_blank" className="flex items-center gap-3 pt-10 text-xs" rel="noreferrer">
+                    <FiVideo />
+                    {' '}
+                    HOW TO VIDEO
+                  </a>
+                )}
+
+            <Categories
+              tags={tags}
+            />
+
+          </div>
 
         </div>
-
-      </div>
+      )}
     </>
+
   );
 }

--- a/src/components/summaryDetail/SummaryDetail.jsx
+++ b/src/components/summaryDetail/SummaryDetail.jsx
@@ -30,7 +30,7 @@ export default function SummaryDetail({
 
   const containerStyle = {
     transform: isDetailShown ? 'translateX(0)' : 'translateX(100%)',
-    transition: 'transform 1s ease',
+    transition: 'transform 0.6s ease',
   };
 
   function toggleNutrition() {


### PR DESCRIPTION
This PR links to Issue #52 

### What changes did you make?
-  The close button in SummaryDetail now stays fixed in the upper right corner - I added "fixed" to the Tailwind classes in the button element.
- SummaryDetail now "slides" in and out. To achieve this, I removed the conditional rendering of SummaryDetail in App.jsx. SummaryDetail is now always rendered, and whether it is viewable or not is controlled by the CSS.
- The picture at the top of SummaryDetail spreads across the entire width of the component and zoom in on the image, without increasing the height of the div it's contained in. I followed the example of the CSS in the RecipeCard components to do this.
- I added bullet points to the ingredient list.
- I made the Nutrition element a flex box so the description of the nutrition element and the value can be justified with space between. I also bolded the calories row of the Nutrition element.
- I added media queries for the container around the Ingredients element and Nutrition element, to change the flex direction from column on cellphones to row on all other screen sizes.

### Why did you make these changes?
- To more closely match the Figma design specifications.

### Screenshots

<details><summary>Summary detail top image and close button</summary>

![Screenshot 2023-11-15 at 10 33 58 AM](https://github.com/chingu-voyages/v46-tier2-team-20/assets/114596142/1643f238-ea44-4d88-8a99-8ef48b013fbb)

</details> 

<details><summary>Cell phone - ingredients and nutrition</summary>

![Screen Shot 2023-11-15 at 10 29 41](https://github.com/chingu-voyages/v46-tier2-team-20/assets/114596142/941d5f80-eb1a-48ab-9352-0b75c9cebc2c)

</details> 

<details><summary>Larger screens - ingredients and nutrition</summary>

![Screenshot 2023-11-15 at 10 29 55 AM](https://github.com/chingu-voyages/v46-tier2-team-20/assets/114596142/a8fd7486-6a8a-49b4-baaa-1616c539f623)

</details> 